### PR TITLE
修复了新版headless不兼容问题

### DIFF
--- a/src/browser/Browser.ts
+++ b/src/browser/Browser.ts
@@ -25,6 +25,8 @@ class Browser {
     }
 
     async createBrowser(proxy: AccountProxy, email: string): Promise<BrowserContext> {
+		const headless = this.bot.config.headless ? "--headless=new" : ""
+		
         const browser = await playwright.chromium.launch({
             channel: 'msedge', // Uses Edge instead of chrome
             headless: this.bot.config.headless,
@@ -35,7 +37,8 @@ class Browser {
                 '--disable-setuid-sandbox',
                 '--ignore-certificate-errors',
                 '--ignore-certificate-errors-spki-list',
-                '--ignore-ssl-errors'
+                '--ignore-ssl-errors',
+				`${headless}`
             ]
         })
 


### PR DESCRIPTION
在新版edge中，如果设置config.json中"headless": true，就会导致报错：

> Old Headless mode has been removed from the Microsoft Edge binary. Please use the new Headless mode (https://developer.chrome.com/docs/chromium/new-headless) or the chrome-headless-shell which is a standalone implementation of the old Headless mode (https://developer.chrome.com/blog/chrome-headless-shell).

该PR旨在修复这个问题